### PR TITLE
Ws/fix graph size

### DIFF
--- a/web/src/components/ForceGraph/ForceGraph.tsx
+++ b/web/src/components/ForceGraph/ForceGraph.tsx
@@ -66,6 +66,7 @@ const ForceGraph = ({ nodes, edges }) => {
 
     window.addEventListener('resize', debouncedHandleResize)
 
+    {/* TODO: fix possible memory leak with adding new event listeners on each screen resize */}
     return _ => {
       window.removeEventListener('resize', debouncedHandleResize)
     }

--- a/web/src/components/ForceGraph/ForceGraph.tsx
+++ b/web/src/components/ForceGraph/ForceGraph.tsx
@@ -1,11 +1,12 @@
 import { Graph } from 'react-d3-graph'
 import { navigate, routes } from '@redwoodjs/router'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import ProfilePanel from '../ProfilePanel/ProfilePanel'
 
 const ForceGraph = ({ nodes, edges }) => {
   const [selectedPerson, setSelectedPerson] = useState(0)
   const [showPanel, setShowPanel] = useState(false)
+  const [dimensions, setDimensions] = useState({})
   const state = {
     data: {
       nodes: nodes,
@@ -15,8 +16,8 @@ const ForceGraph = ({ nodes, edges }) => {
       })),
     },
     config: {
-      height: 400,
-      width: 400,
+      height: window.innerHeight,
+      width: window.innerWidth,
       automaticRearrangeAfterDropNode: true,
       freezeAllDragEvents: false,
       staticGraph: false,
@@ -43,6 +44,19 @@ const ForceGraph = ({ nodes, edges }) => {
     },
     fontSize: 12,
   }
+
+  React.useEffect(() => {
+    function handleResize() {
+      setDimensions({
+        height: window.innerHeight,
+        width: window.innerWidth
+      })
+    }
+    window.addEventListener('resize', handleResize)
+    return _ => {
+      window.removeEventListener('resize', handleResize)
+    }
+  })
 
   const onClickNode = (nodeId) => {
     // navigate(routes.profile({ id: nodeId }))

--- a/web/src/components/ForceGraph/ForceGraph.tsx
+++ b/web/src/components/ForceGraph/ForceGraph.tsx
@@ -45,16 +45,29 @@ const ForceGraph = ({ nodes, edges }) => {
     fontSize: 12,
   }
 
-  React.useEffect(() => {
-    function handleResize() {
+  function debounce(fn, ms) {
+    let timer
+    return _ => {
+      clearTimeout(timer)
+      timer = setTimeout(_ => {
+        timer = null
+        fn.apply(this, arguments)
+      }, ms)
+    };
+  }
+
+  useEffect(() => {
+    const debouncedHandleResize = debounce(function handleResize() {
       setDimensions({
         height: window.innerHeight,
         width: window.innerWidth
       })
-    }
-    window.addEventListener('resize', handleResize)
+    }, 50)
+
+    window.addEventListener('resize', debouncedHandleResize)
+
     return _ => {
-      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('resize', debouncedHandleResize)
     }
   })
 


### PR DESCRIPTION
There's an issue where the graph is created out of frame when clicking away and then clicking back to home. It only happens when the graph has already been generated once (so refreshing the page on profiles and then switching to home, for example, will generate a graph properly). Refreshing fixes the graph, but it definitely needs addressing.